### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-required.yaml
+++ b/.github/workflows/pull-required.yaml
@@ -1,5 +1,7 @@
 ---
 name: cli pull request pipeline.
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/code-gorilla-au/goety/security/code-scanning/2](https://github.com/code-gorilla-au/goety/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. The best way to do this is to add the block at the top level of the workflow (just after the `name:` line), so it applies to all jobs unless overridden. Since the jobs in this workflow only check out code and run scanners and tests, they likely only need read access to repository contents. Therefore, set `permissions: contents: read` at the workflow level. No changes to the jobs themselves are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
